### PR TITLE
Add multi-model randomization

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ export OPENAI_API_KEY=fake-api-key
 python auto_bemchmark.py --model meta-llama/Meta-Llama-3-8B-Instruct --docker-image IMAGE_ID --input-tokens 100 --output-tokens 100 --concurrency 1
 ```
 
+Multiple models can be benchmarked by listing them in your engine config YAML:
+
+```yaml
+args:
+  model:
+    - modelA
+    - modelB
+    - modelC
+```
+
 Litellm proxy benchmarking
 
 ```bash

--- a/llm_benchmark/benchmark/tools.py
+++ b/llm_benchmark/benchmark/tools.py
@@ -1,7 +1,7 @@
 import os
 import csv
 import shutil
-from typing import Optional
+from typing import Optional, Union, List
 from uuid import UUID
 
 from llm_benchmark.benchmark.vllm_benchmark.benchmark_serving import (
@@ -245,7 +245,7 @@ def format_budlatent_result(result):
 
 
 def run_benchmark(
-    model: str,
+    model: Union[str, List[str]],
     base_url: str,
     input_token: int,
     output_token: int,
@@ -274,8 +274,15 @@ def run_benchmark(
         datasets
     )
 
+    if isinstance(model, list):
+        model_str = ",".join(model)
+        model_dir = model[0].replace("/", "--")
+    else:
+        model_str = model
+        model_dir = model.replace("/", "--")
+
     if result_dir is not None:
-        result_dir = os.path.join(result_dir, model.replace("/", "--"))
+        result_dir = os.path.join(result_dir, model_dir)
 
         traces_dir = f"{result_dir}/profiler_traces/"
         if os.path.exists(traces_dir):
@@ -283,8 +290,8 @@ def run_benchmark(
         os.makedirs(traces_dir, exist_ok=True)
 
     print(
-        "Running benchmark for model: ",
-        model,
+        "Running benchmark for model(s): ",
+        model_str,
         "with input token: ",
         input_token,
         "and output token: ",


### PR DESCRIPTION
## Summary
- allow listing multiple models in engine config YAML
- randomize model choice per request in `llmperf` benchmark
- support list of models through benchmark tooling
- document multi-model option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
